### PR TITLE
Word 'assets'  missing on line 35 of site/docs/index.md: 'if you want…

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -32,9 +32,9 @@ $ cd example
 $ npm install --save arwes
 ```
 
-Images and sounds are not provided, if you want to use the implemented in the docs,
+Images and sounds are not provided, if you want to use the assets implemented in the docs,
 download them from the static folder in the
-[repository in GitHub](https://github.com/romelperez/arwes).
+[GitHub repository](https://github.com/romelperez/arwes).
 
 Once installed, enter to the folder and empty the `src/index.js` to start
 from scratch.


### PR DESCRIPTION
This commit fixes a typo on line 35 of site/docs/index.md

Word `assets`  missing on line 35 of site/docs/index.md: `if you want to use the implemented in the docs`

Fixed to read: `if you want to use the assets implemented in the docs`

Also cleaned up `the repository on Github` to `the Github repository` at the end of the paragraph, on line 37

